### PR TITLE
Ignored Pylint issue 'consider-using-f-string' in new Pylint 2.11

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -24,6 +24,9 @@ Released: not yet
 
 * Fixed new issues raised by Pylint 2.10.
 
+* Disabled new Pylint issue 'consider-using-f-string', since f-strings were
+  introduced only in Python 3.6.
+
 **Enhancements:**
 
 **Cleanup:**

--- a/pylintrc
+++ b/pylintrc
@@ -68,7 +68,7 @@ disable=I0011,
         wildcard-import, unused-wildcard-import,
         locally-enabled, superfluous-parens, useless-object-inheritance,
         consider-using-set-comprehension, unnecessary-pass, useless-return,
-        bad-option-value, super-with-arguments
+        bad-option-value, super-with-arguments, consider-using-f-string
 
 # Note: "useless-object-inheritance" is python 3 only. In Python 2,
 #        "new-style" objects must inherit from object, or else


### PR DESCRIPTION
No review needed