### PR TITLE
Fixed install error of wrapt 1.13.0 on Python 2.7/3.4

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -75,6 +75,9 @@ typed-ast>=1.3.0,<1.4.0; python_version == '3.4' and implementation_name=='cpyth
 typed-ast>=1.4.0,<1.5.0; python_version >= '3.5' and python_version < '3.8' and implementation_name=='cpython'
 # platformdirs is used by pylint starting with its 2.10
 platformdirs>=2.2.0; python_version >= '3.6'
+wrapt>=1.11.2,<1.13; python_version == '2.7'
+wrapt>=1.11.2,<1.13; python_version == '3.4'
+wrapt>=1.11.2; python_version >= '3.5'
 
 # Flake8 and dependents (no imports, invoked via flake8 script):
 # flake8 3.9.0 has removed support for py34 and pip 19.1.1 on py34 does not deal
@@ -143,4 +146,3 @@ colorama>=0.4.0; python_version >= '3.5'
 # tqdm
 # urllib3
 # webencodings
-# wrapt

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -27,6 +27,8 @@ Released: not yet
 * Disabled new Pylint issue 'consider-using-f-string', since f-strings were
   introduced only in Python 3.6.
 
+* Fixed install error of wrapt 1.13.0 on Python 2.7/3.4, by pinning it to <1.13.
+
 **Enhancements:**
 
 **Cleanup:**

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -180,6 +180,7 @@ astroid==2.3.3; python_version >= '3.5'
 typed-ast==1.3.0; python_version == '3.4' and implementation_name=='cpython'
 typed-ast==1.4.0; python_version >= '3.5' and python_version < '3.8' and implementation_name=='cpython'
 platformdirs==2.2.0; python_version >= '3.6'
+wrapt==1.11.2
 
 # Flake8 and dependents (no imports, invoked via flake8 script):
 flake8==3.8.0
@@ -260,4 +261,3 @@ typing==3.6.1; python_version < '3.5'
 urllib3==1.23
 wcwidth==0.1.7
 webencodings==0.5.1
-wrapt==1.11.2


### PR DESCRIPTION
No review needed.