### PR TITLE
Fixed Sphinx/docutils error on Python 2.7

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -47,7 +47,15 @@ importlib-metadata<1,>=0.12; python_version < '3.8'
 
 # Sphinx (no imports, invoked via sphinx-build script):
 # Keep in sync with rtd-requirements.txt
-Sphinx>=1.7.6
+
+# Sphinx 2.0.0 removed support for Python 2.7 and 3.4
+# Sphinx 4.0.0 breaks autodocsumm and needs to be excluded
+# Sphinx pins docutils to <0.18 (some versions even to <0.17) but the package
+#   version resolver in the pip version used on py27 ignores package dependencies
+Sphinx>=1.7.6,<2.0.0; python_version <= '3.4'
+Sphinx>=3.5.4,!=4.0.0; python_version >= '3.5'
+docutils>=0.13.1,<0.17; python_version == '2.7'
+docutils>=0.13.1; python_version >= '3.4'
 sphinx-git>=10.1.1
 GitPython>=2.1.1
 sphinxcontrib-fulltoc>=1.2.0
@@ -121,7 +129,6 @@ colorama>=0.4.0; python_version >= '3.5'
 # bleach
 # certifi
 # chardet
-# docutils
 # Click
 # gitdb
 # idna

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -30,6 +30,8 @@ Released: not yet
 * Fixed install error of wrapt 1.13.0 on Python 2.7 on Windows due to lack of
   MS Visual C++ 9.0 on GitHub Actions, by pinning it to <1.13.
 
+* Fixed TypeError when running Sphinx due to using docutils 0.18 on Python 2.7.
+
 **Enhancements:**
 
 * Enhanced test matrix on GitHub Actions to always include Python 2.7 and

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -161,7 +161,9 @@ tox==2.5.0
 importlib-metadata==0.12; python_version < '3.8'
 
 # Sphinx (no imports, invoked via sphinx-build script):
-Sphinx==1.7.6
+Sphinx==1.7.6; python_version <= '3.4'
+Sphinx==3.5.4; python_version >= '3.5'
+docutils==0.13.1
 sphinx-git==10.1.1
 GitPython==2.1.1
 sphinxcontrib-fulltoc==1.2.0
@@ -221,7 +223,6 @@ Click==7.0
 clint==0.5.1; python_version == '2.7'
 configparser==4.0.2; python_version < '3.2'
 distlib==0.3.0; python_version >= '3.4'
-docutils==0.13.1
 enum34==1.1.6; python_version < '3.4'
 filelock==3.0.0; python_version >= '3.4'
 funcsigs==1.0.2; python_version == '2.7'

--- a/rtd-requirements.txt
+++ b/rtd-requirements.txt
@@ -4,7 +4,10 @@
 # of appearance.
 
 # Sphinx (no imports, invoked via sphinx-build script):
-Sphinx>=1.7.6
+Sphinx>=1.7.6,<2.0.0; python_version <= '3.4'
+Sphinx>=3.5.4,!=4.0.0; python_version >= '3.5'
+docutils>=0.13.1,<0.17; python_version == '2.7'
+docutils>=0.13.1; python_version >= '3.4'
 sphinx-git>=10.1.1
 GitPython>=2.1.1
 sphinxcontrib-fulltoc>=1.2.0


### PR DESCRIPTION
See commit message.
No review needed.