### PR TITLE
Added Python 3.7 to standard test runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ jobs:
         else \
           echo "::set-output name=matrix::{ \
             \"os\": [ \"ubuntu-latest\" ], \
-            \"python-version\": [ \"2.7\", \"3.10\" ], \
+            \"python-version\": [ \"2.7\", \"3.7\", \"3.10\" ], \
             \"package_level\": [ \"minimum\", \"latest\" ], \
             \"include\": [ \
               { \


### PR DESCRIPTION
No review needed.
This reproduces issue #83 on py37/latest, which will be fixed later.