### PR TITLE
Eliminated warnings about node v16

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -165,11 +165,11 @@ jobs:
       PIP_NO_PYTHON_VERSION_WARNING: 1
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Display initial Python packages

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -26,6 +26,9 @@ Released: not yet
 
 **Cleanup:**
 
+* Test: Increased vrsions of GitHub Actions plugins used, to eliminate warnings
+  about node v16.
+
 **Known issues:**
 
 * See `list of open issues`_.


### PR DESCRIPTION
No review needed.