### PR TITLE
2.0: Fixed coveralls not found on MacOS with py39-311

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -138,6 +138,11 @@ jobs:
               }, \
               { \
                 \"os\": \"macos-latest\", \
+                \"python-version\": \"3.11\", \
+                \"package_level\": \"latest\" \
+              }, \
+              { \
+                \"os\": \"macos-latest\", \
                 \"python-version\": \"3.12\", \
                 \"package_level\": \"latest\" \
               }, \
@@ -249,7 +254,6 @@ jobs:
       run: |
         make doclinkcheck
     - name: Send coverage result to coveralls.io
-      shell: bash -l {0}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         COVERALLS_PARALLEL: true

--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ else
   RMDIR_R_FUNC = find . -type d -name '$(1)' | xargs -n 1 rm -rf
   CP_FUNC = cp -r $(1) $(2)
   ENV = env | sort
-  WHICH = which
+  WHICH = which -a
 endif
 
 # Name of this project

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -16,6 +16,10 @@ Released: not yet
 
 **Bug fixes:**
 
+* Test: Fixed the issue that coveralls was not found in the test workflow on MacOS
+  with Python 3.9-3.11, by running it without login shell. Added Python 3.11 on
+  MacOS to the normal tests.
+
 **Enhancements:**
 
 **Cleanup:**


### PR DESCRIPTION
Rolls back PR #199 into 2.0.4.