### PR TITLE
Safety issues up to 2025-01-29; Fixed twine dependencies

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -27,7 +27,7 @@ Released: not yet
 
 **Bug fixes:**
 
-* Addressed safety issues up to 2024-11-30.
+* Addressed safety issues up to 2025-01-29.
 
 * Test: Fixed the issue that coveralls was not found in the test workflow on MacOS
   with Python 3.9-3.11, by running it without login shell. Added Python 3.11 on

--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -127,6 +127,7 @@ distlib==0.3.7
 docopt==0.6.1
 filelock==3.13.1
 gitdb==4.0.1
+id==1.5.0
 # idna>3 requires using requests >=2.26.0
 idna==3.7
 imagesize==1.3.0

--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -130,7 +130,7 @@ gitdb==4.0.1
 # idna>3 requires using requests >=2.26.0
 idna==3.7
 imagesize==1.3.0
-Jinja2==3.1.4
+Jinja2==3.1.5
 keyring==17.0.0
 MarkupSafe==2.0.0
 more-itertools==5.0.0


### PR DESCRIPTION
No review needed.