### PR TITLE
Added retries for sending coverage data to the coveralls.io

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -209,8 +209,12 @@ jobs:
         COVERALLS_SERVICE_NAME: github
         COVERALLS_SERVICE_JOB_ID: "${{ github.run_id }}"
         COVERALLS_SERVICE_NUMBER: "${{ github.workflow }}-${{ github.run_number }}"
-      run: |
-        coveralls
+      uses: nick-fields/retry@v3
+      with:
+        timeout_seconds: 30
+        max_attempts: 3
+        retry_wait_seconds: 15
+        command: coveralls
     - name: Run installtest
       env:
         PACKAGE_LEVEL: ${{ matrix.package_level }}
@@ -236,5 +240,9 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         COVERALLS_SERVICE_NUMBER: "${{ github.workflow }}-${{ github.run_number }}"
-      run: |
-        coveralls --finish
+      uses: nick-fields/retry@v3
+      with:
+        timeout_seconds: 30
+        max_attempts: 3
+        retry_wait_seconds: 15
+        command: coveralls --finish

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -33,6 +33,9 @@ Released: not yet
 
 **Cleanup:**
 
+* Test: Added retries for sending coverage data to the coveralls.io site to
+  address issues with the site.
+
 **Known issues:**
 
 * See `list of open issues`_.


### PR DESCRIPTION
No review needed.